### PR TITLE
Add Base64 and Bigdecimal gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 # Gemfile
 source "https://rubygems.org"
+
+gem "base64"
+gem "bigdecimal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
 
 PLATFORMS
   arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
+  base64
+  bigdecimal
 
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
These were removed from the Ruby standard library starting in Ruby 3.4. We're still defaulting to Ruby 3.3.x, but this will help eliminate some deprecation warnings.

This is how it was previously configured: https://github.com/heroku-examples/code-execution-ruby/blob/main/Gemfile