### PR TITLE
Environment variables should be strings

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
         },
         "STDIO_MODE_ONLY": {
             "description": "Only allow tool requests via STDIO mode?",
-            "value": false
+            "value": "false"
         }
     },
     "formation": [
@@ -26,7 +26,11 @@
     ],
     "addons": [],
     "buildpacks": [
-        { "url": "heroku/python" },
-        { "url": "heroku/ruby" }
+        {
+            "url": "heroku/python"
+        },
+        {
+            "url": "heroku/ruby"
+        }
     ]
 }


### PR DESCRIPTION
The boolean values here tend to break deployments to Heroku.

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002EPqs7YAD/view)