### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-src/__pycache__/*
+__pycache__/
+.cursor/
+Makefile


### PR DESCRIPTION
Adds `.gitignore` to exclude local development artifacts: `__pycache__/`, `.cursor/`, and `Makefile`.